### PR TITLE
[fix] Compare existing user in all cases

### DIFF
--- a/src/AllMentors.js
+++ b/src/AllMentors.js
@@ -75,7 +75,7 @@ export default function Mentors() {
 
   function handleUserExists(name) {
     return mentorList.some((mentor) => {
-      return mentor.userName === name;
+      return mentor.userName === name.toLowerCase();
     });
   }
 


### PR DESCRIPTION
Small fix to compare the lowercase of newly entered username with existing usernames as they are stored in lowercase. This prevents user from adding same Twitter Mentor username if not entered in lowercase.